### PR TITLE
pass arguments to pandas read files

### DIFF
--- a/wosplus/wosplus.py
+++ b/wosplus/wosplus.py
@@ -196,7 +196,7 @@ class wosplus:
         else:
             return pd.read_csv(file_name, **kwargs)
 
-    def load_biblio(self, WOS_file, prefix='WOS'):
+    def load_biblio(self, WOS_file, prefix='WOS',**kwargs):
         """
         Load WOS xlsx file, or if prefix is given:
           prefix='SCI': Load SCI xlsx file and append the 'SCI_' prefix in each column
@@ -211,15 +211,15 @@ class wosplus:
         # elif: #Other no WOS-like pures
 
         if not re.search('\.txt$', WOS_file):
-            if re.search('\.json$', WOS_file):
-                WOS = self.read_drive_json(WOS_file)
+            if re.search('\.json', WOS_file):
+                WOS = self.read_drive_json(WOS_file,**kwargs)
             else:
-                WOS = self.read_drive_excel(WOS_file)
+                WOS = self.read_drive_excel(WOS_file,**kwargs)
         else:
             id_google_drive = self.drive_file.get('{}'.format(WOS_file))
             if id_google_drive:
                 wos_txt = download_file_from_google_drive(
-                    id_google_drive)  # ,binary=False)
+                    id_google_drive,**kwargs)  # ,binary=False)
                 WOS = wos_to_list_to_pandas(wos_txt)
             else:  # check local file
                 my_file = Path(WOS_file)


### PR DESCRIPTION
Allows to pass arguments to read_drive_excel, read_drive_json and download_file_from_google_drive. 
In this way the following operations are now possible:

cib.load_biblio('Sample_WOS.xlsx',header=1)
cib.load_biblio('Sample_WOS.json.gz',compression='gzip')

The last one can be tested from:
Sample_WOS.json.gz=1Jzb8_mysmOBGFsmyHspldF99SdNoufdY